### PR TITLE
Syntax fix for rullette mechanism

### DIFF
--- a/DAPathfinder/GeneticAlgorithm/GeneticAlgorithm.swift
+++ b/DAPathfinder/GeneticAlgorithm/GeneticAlgorithm.swift
@@ -72,7 +72,7 @@ class GeneticAlgorithm
     }
     
     private func getParent(fromGeneration generation: [Route], withTotalDistance totalDistance: CGFloat) -> Route? {
-        let fitness = CGFloat(arc4random() / UINT32_MAX)
+        let fitness = CGFloat(Double(arc4random()) / Double(UINT32_MAX)) * (generation.count - 1)
         
         var currentFitness: CGFloat = 0.0
         var result: Route?


### PR DESCRIPTION
Hi @dagostini!
I loved your article, but I think that your roulette mechanism has some tiny bug. Besides a fact that `fitness` was always 0 (since division is made on UInt32 and floor'ed to 0) that this PR regards fitness function seems to be not perfect too. 

For sample 500 routes we have fitness values almost the same and equal to 1 (differences are very tiny). Therefore roulette works in practice as a random and thus the algorithm is non-stable. What if (I have zero knowledge about genetic algorithms at all) we relax requirement about `fitness` being normalized to 1? What if:
```
func fitness(withWorstDistance worstValue: CGFloat) -> CGFloat {
   return worstValue - distance
}
```
and then 
```
private func getParent(fromGeneration generation: [Route], withWorstDistance worstDistance: CGFloat) -> Route? {
        let fitnesses = generation.map({$0.fitness(withWorstDistance: worstDistance)}) //super inefficient
        let sumOfFitnesses = fitnesses.reduce(0, +) //inefficent too, I know
        let fitness = CGFloat(Double(arc4random()) / Double(UINT32_MAX)) * sumOfFitnesses
        
        var currentFitness: CGFloat = 0.0
        var result: Route?
        generation.forEach { (route) in
            if currentFitness <= fitness {
                currentFitness += route.fitness(withWorstDistance: worstDistance)
                result = route
            }
        }
        
        return result
    }
```
Above code is just a sketch to note that is such cases, almost all distances have a chance to "survive" while we still promote "better routes (aka genes)" ...